### PR TITLE
updated schema generation

### DIFF
--- a/src/Altinn.Dan.Plugin.Trad/Metadata.cs
+++ b/src/Altinn.Dan.Plugin.Trad/Metadata.cs
@@ -4,7 +4,6 @@ using Dan.Common.Enums;
 using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Newtonsoft.Json;
-using NJsonSchema.NewtonsoftJson.Generation;
 
 namespace Altinn.Dan.Plugin.Trad
 {
@@ -114,7 +113,7 @@ namespace Altinn.Dan.Plugin.Trad
                         {
                             EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
-                            JsonSchemaDefintion = NewtonsoftJsonSchemaGenerator.FromType<PersonExternal>().ToJson(Formatting.None),
+                            JsonSchemaDefintion = EvidenceValue.SchemaFromObject<PersonExternal>(Formatting.None),
                         }
                     },
                     AuthorizationRequirements = new List<Requirement>
@@ -136,7 +135,7 @@ namespace Altinn.Dan.Plugin.Trad
                         {
                             EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
-                            JsonSchemaDefintion = NewtonsoftJsonSchemaGenerator.FromType<PersonPrivate>().ToJson(Formatting.None),
+                            JsonSchemaDefintion = EvidenceValue.SchemaFromObject<PersonPrivate>(Formatting.None),
                         }
                     },
                     AuthorizationRequirements = new List<Requirement>


### PR DESCRIPTION
### Description
<!--- What and why -->
Use EvidenceValue.SchemaFromObject instead of JsonSchema.FromType().ToJson().

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generation of evidence JSON schemas for person-related data.
  * Maintained consistent schema output while removing an outdated schema-generation dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->